### PR TITLE
Skip adding sidebar to map popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Throw exceptions when log-types/asset-types/taxonomy-vocabularies are missing
 - Clean up tests a little
 - Rename OpenInFarmOSMetaActionProvider plugin to OpenAssetInFarmOSMetaActionProvider for clarity
+- Skip adding sidebar to map popups
 
 ### Fixed
 

--- a/farmos_asset_link/js/farmos_asset_link_sidecar.js
+++ b/farmos_asset_link/js/farmos_asset_link_sidecar.js
@@ -1,5 +1,9 @@
 /* eslint-disable-next-line no-console */
 (async function main() {
+  if (window.location.href.includes('/map-popup')) {
+    // Skip adding sidebar to map popups.
+    return;
+  }
   const matches = window.location.href.match(/https?:\/\/.*\/asset\/(\d+)/);
 
   console.log(matches);


### PR DESCRIPTION
Fixes https://github.com/symbioquine/farmOS_asset_link/issues/28 by skipping adding Asset Link sidebar to map popups.
On the map, asset popups are displaying iframes loading `/asset/{id}/map-popup` page. This pr adds an if statement before attempting to load the Asset Link sidebar to check if the current url includes `/map-popup` and if so then the sidebar loading is skipped.