### PR TITLE
Support farmOS 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Declare support for farmOS 4.x #49](Declare support for farmOS 4.x #49)
+
 ## [1.0.0-alpha16] - 2024-11-18
 
 ### Added

--- a/farmos_asset_link/composer.json
+++ b/farmos_asset_link/composer.json
@@ -17,6 +17,7 @@
   "license": "GPL-3.0-or-later",
   "minimum-stability": "dev",
   "require": {
-    "drupal/subrequests": "^3.0"
+    "drupal/subrequests": "^3.0",
+    "farmos/farmos": "^2 || ^3 || ^4"
   }
 }

--- a/farmos_asset_link/farmos_asset_link.info.yml
+++ b/farmos_asset_link/farmos_asset_link.info.yml
@@ -2,6 +2,6 @@ name: farmOS Asset Link
 description: Supercharges links to your farmOS assets with an extensible hybrid PWA experience.
 type: module
 package: farmOS Contrib
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - subrequests:subrequests


### PR DESCRIPTION
This changes the version constraint in `farmos_asset_link.info.yml` to declare that the module can be installed on farmOS 4.x.

It also adds `farmos/farmos` as a requirement to `composer.json`. This helps provide control over which versions the module is compatible with when you run `composer require drupal/farmos_asset_link` (eg: so that you can drop support when necessary and Composer won't let it be installed where it isn't compatible).