### PR TITLE
Depend on farmOS API module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Depend on farmOS API module #50](https://github.com/symbioquine/farmOS_asset_link/pull/50)
+
 ## [1.0.0-alpha18] - 2026-03-17
 
 ### Changed

--- a/farmos_asset_link/farmos_asset_link.info.yml
+++ b/farmos_asset_link/farmos_asset_link.info.yml
@@ -4,4 +4,4 @@ type: module
 package: farmOS Contrib
 core_version_requirement: ^9 || ^10 || ^11
 dependencies:
-  - subrequests:subrequests
+  - farm_api


### PR DESCRIPTION
The farm_api module is optional in farmOS v4.

See: https://github.com/farmOS/farmOS/pull/974

We can also remove the depenency on subrequests at the same time, because farm_api depends on that already.